### PR TITLE
Use our newest Lambda module; flesh out the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # search-logger
 
-This is a Lambda function which logs user searches to the reporting cluster.
+This is a tool which logs user searches to our "reporting" Elasticsearch cluster.
 These logs include:
 
 *   what search term somebody typed in
@@ -8,7 +8,7 @@ These logs include:
 *   which results (if any) that they clicked on.
 
 We use this to analyse search behaviour and improve our queries.
-For example, we can look at searches that return 0 results and discuss whether we should be returning something for those searches.
+For example, we can look at searches that return 0 results and discuss whether there really are no results, or whether we should change the results we return.
 
 ## How search events get logged
 
@@ -29,6 +29,11 @@ flowchart LR
 Our website [sends tracking events][track.ts] to [Segment].
 Those segments are forwarded to a [Kinesis data stream][kinesis], which triggers a Lambda function.
 That Lambda function writes the search logs into the [reporting cluster].
+
+This repo contains:
+
+*   the source code for the Lambda function
+*   the Terraform definitions for the Kinesis stream and the Lambda function
 
 [track.ts]: https://github.com/wellcomecollection/wellcomecollection.org/blob/9115873707b411a1ecfe2a93f5ebf7f240861c8f/common/services/conversion/track.ts#L6
 [Segment]: https://segment.com/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,49 @@
 # search-logger
 
-Accepts data from [Segment](https://segment.com/) via [Kinesis](https://segment.com/docs/destinations/amazon-kinesis/). 
+This is a Lambda function which logs user searches to the reporting cluster.
+These logs include:
 
-The kinesis stream triggers a lambda which writes into the ElasticCloud hosted [Reporting ES cluster](https://reporting.wellcomecollection.org).
+*   what search term somebody typed in
+*   how many results we returned
+*   which results (if any) that they clicked on.
 
-This is provisioned in the Experience AWS account.
+We use this to analyse search behaviour and improve our queries.
+For example, we can look at searches that return 0 results and discuss whether we should be returning something for those searches.
+
+## How search events get logged
+
+```mermaid
+flowchart LR
+    W[website] --> S[Segment]
+    S[Segment] --> K[Kinesis stream]
+    K --> L[search logger Lambda]
+    L --> R[(reporting<br/>cluster)]
+
+    classDef externalNode fill:#e8e8e8,stroke:#8f8f8f
+    class S,R,W externalNode
+
+    classDef repoNode fill:#c8ecee,stroke:#298187,stroke-width:2px
+    class K,L repoNode
+```
+
+Our website [sends tracking events][track.ts] to [Segment].
+Those segments are forwarded to a [Kinesis data stream][kinesis], which triggers a Lambda function.
+That Lambda function writes the search logs into the [reporting cluster].
+
+[track.ts]: https://github.com/wellcomecollection/wellcomecollection.org/blob/9115873707b411a1ecfe2a93f5ebf7f240861c8f/common/services/conversion/track.ts#L6
+[Segment]: https://segment.com/
+[kinesis]: https://segment.com/docs/destinations/amazon-kinesis/
+[reporting cluster]: https://reporting.wellcomecollection.org
+
+## Developer info
+
+*   To deploy a new version the function:
+
+    ```console
+    $ cd lambda
+    $ yarn deploy
+    $ cd ../terraform
+    $ ./run_terraform.sh apply
+    ```
+
+*   You can see the Lambda logs <a href="https://logging.wellcomecollection.org/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:cb5ba262-ec15-46e3-a4c5-5668d65fe21f,key:service,negate:!f,params:(query:%2Faws%2Flambda%2Fsearch_logger_kinesis_to_es_lambda),type:phrase),query:(match_phrase:(service:%2Faws%2Flambda%2Fsearch_logger_kinesis_to_es_lambda)))),index:cb5ba262-ec15-46e3-a4c5-5668d65fe21f,interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))">in the logging cluster</a>.

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -66,7 +66,9 @@ module "search_logger" {
   s3_object_version = data.aws_s3_object.search_logger_kinesis_to_es_lambda_s3_object.version_id
   publish           = true
 
-  # used to be 3 seconds
+  # Note: this timeout was originally 3 seconds, but we increased it when
+  # we saw the Lambda timing out.  It processes events from Kinesis in batches
+  # of 100, so this should be plenty.
   timeout = 60
 
   error_alarm_topic_arn = local.lambda_error_alert_arn

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -54,21 +54,6 @@ data "aws_s3_object" "search_logger_kinesis_to_es_lambda_s3_object" {
   key    = local.lambda_file_name
 }
 
-moved {
-  from = aws_lambda_function.search_logger_kinesis_to_es_lambda
-  to = module.search_logger.aws_lambda_function.main
-}
-
-moved {
-  from = aws_iam_role.search_logger_kinesis_to_es_lambda_role
-  to   = module.search_logger.aws_iam_role.lambda
-}
-
-moved {
-  from = module.search_logger_lambda
-  to   = module.search_logger
-}
-
 module "search_logger" {
   source = "git@github.com:wellcomecollection/terraform-aws-lambda.git?ref=v1.2.0"
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -3,20 +3,6 @@ locals {
   lambda_bucket_name = "search-logger"
 }
 
-data "aws_iam_policy_document" "search_logger_kinesis_to_es_lambda_policy_document" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type = "Service"
-
-      identifiers = [
-        "lambda.amazonaws.com",
-      ]
-    }
-  }
-}
-
 data "aws_iam_policy_document" "kms_decrypt_env_vars" {
   statement {
     actions   = ["kms:Decrypt"]
@@ -43,28 +29,23 @@ resource "aws_iam_policy" "search_logger_kinesis_to_es_secrets_manager_read_es_d
   policy      = data.aws_iam_policy_document.secrets_manager_es_details_read.json
 }
 
-resource "aws_iam_role" "search_logger_kinesis_to_es_lambda_role" {
-  name               = "SearchLoggerKinesisToEsLambdaRole"
-  assume_role_policy = data.aws_iam_policy_document.search_logger_kinesis_to_es_lambda_policy_document.json
-}
-
 resource "aws_iam_role_policy_attachment" "lambda_kinesis_kms_decrypt" {
-  role       = aws_iam_role.search_logger_kinesis_to_es_lambda_role.id
+  role       = module.search_logger_lambda.lambda_role.id
   policy_arn = aws_iam_policy.search_logger_kinesis_to_es_kms_decrypt_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_kinesis_secrets_manager_read_es_details" {
-  role       = aws_iam_role.search_logger_kinesis_to_es_lambda_role.id
+  role       = module.search_logger_lambda.lambda_role.id
   policy_arn = aws_iam_policy.search_logger_kinesis_to_es_secrets_manager_read_es_details.arn
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution_role_attachement" {
-  role       = aws_iam_role.search_logger_kinesis_to_es_lambda_role.id
+  role       = module.search_logger_lambda.lambda_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_kinesis_execution_role_attachement" {
-  role       = aws_iam_role.search_logger_kinesis_to_es_lambda_role.id
+  role       = module.search_logger_lambda.lambda_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
 }
 
@@ -73,9 +54,21 @@ data "aws_s3_object" "search_logger_kinesis_to_es_lambda_s3_object" {
   key    = local.lambda_file_name
 }
 
-resource "aws_lambda_function" "search_logger_kinesis_to_es_lambda" {
-  function_name     = "search_logger_kinesis_to_es_lambda"
-  role              = aws_iam_role.search_logger_kinesis_to_es_lambda_role.arn
+moved {
+  from = aws_lambda_function.search_logger_kinesis_to_es_lambda
+  to = module.search_logger_lambda.aws_lambda_function.main
+}
+
+moved {
+  from = aws_iam_role.search_logger_kinesis_to_es_lambda_role
+  to   = module.search_logger_lambda.aws_iam_role.lambda
+}
+
+module "search_logger_lambda" {
+  source = "git@github.com:wellcomecollection/terraform-aws-lambda.git?ref=v1.2.0"
+
+  name = "search_logger_kinesis_to_es_lambda"
+
   runtime           = "nodejs12.x"
   handler           = "index.handler"
   s3_bucket         = data.aws_s3_object.search_logger_kinesis_to_es_lambda_s3_object.bucket
@@ -84,11 +77,13 @@ resource "aws_lambda_function" "search_logger_kinesis_to_es_lambda" {
   publish           = true
 
   timeout = 60
+
+  error_alarm_topic_arn = local.lambda_error_alert_arn
 }
 
 resource "aws_lambda_event_source_mapping" "search_logger_kinesis_to_es_lambda_source_mapping" {
   event_source_arn  = aws_kinesis_stream.search_logger_stream.arn
-  function_name     = aws_lambda_function.search_logger_kinesis_to_es_lambda.arn
+  function_name     = module.search_logger_lambda.lambda.arn
   starting_position = "LATEST"
 }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -3,6 +3,8 @@ locals {
   webplatform_account_id = "130871440101"
   stream_name            = "SearchLogger"
   service_name           = "search-logger"
+
+  lambda_error_alert_arn = data.terraform_remote_state.monitoring.outputs["experience_lambda_error_alerts_topic_arn"]
 }
 
 variable "segment_source_id" {}
@@ -16,5 +18,17 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
+  }
+}
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
   }
 }


### PR DESCRIPTION
This gets us two important things:

* We should get Slack alarms if it has an error processing messages, which would have let us spot that it stopped processing messages a day or so ago
* Logs from the search-logger Lambda now go to our shared logging cluster 

Closes https://github.com/wellcomecollection/search-logger/issues/18